### PR TITLE
Patch 1

### DIFF
--- a/android/src/main/java/com/tavernari/volumecontroller/ReactNativeVolumeControllerModule.java
+++ b/android/src/main/java/com/tavernari/volumecontroller/ReactNativeVolumeControllerModule.java
@@ -42,9 +42,11 @@ public class ReactNativeVolumeControllerModule extends ReactContextBaseJavaModul
     }
   }
 
-  public void sendEvent(ReactContext reactContext, String eventName, @Nullable WritableMap params) {
-    this.context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
-  }
+  // public void sendEvent(ReactContext reactContext, String eventName, @Nullable
+  // WritableMap params) {
+  // this.context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName,
+  // params);
+  // }
 
   @ReactMethod
   public void getVolume(Promise promise) {
@@ -54,14 +56,6 @@ public class ReactNativeVolumeControllerModule extends ReactContextBaseJavaModul
   @ReactMethod
   public void change(float volume) {
     am.setStreamVolume(AudioManager.STREAM_MUSIC, (int) (volume * max_volume), 0);
-  }
-
-  @ReactMethod
-  public void update() {
-    float volume = am.getStreamVolume(AudioManager.STREAM_MUSIC) / max_volume;
-    WritableMap params = Arguments.createMap();
-    params.putString("volume", String.valueOf(volume));
-    sendEvent(this.context, "VolumeControllerValueUpdatedEvent", params);
   }
 
   private float getNormalizedVolume() {

--- a/ios/ReactNativeVolumeController/ReactNativeVolumeController.m
+++ b/ios/ReactNativeVolumeController/ReactNativeVolumeController.m
@@ -40,6 +40,10 @@ RCT_EXPORT_MODULE()
     hasListeners = NO;
 }
 
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_main_queue();
+}
+
 - (void)initAudioSessionObserver{
     audioSession = [AVAudioSession sharedInstance];
     [audioSession setActive:YES error:nil];

--- a/ios/ReactNativeVolumeController/ReactNativeVolumeController.m
+++ b/ios/ReactNativeVolumeController/ReactNativeVolumeController.m
@@ -40,13 +40,12 @@ RCT_EXPORT_MODULE()
     hasListeners = NO;
 }
 
-- (dispatch_queue_t)methodQueue {
-  return dispatch_get_main_queue();
++ (BOOL) requiresMainQueueSetup {
+    return YES;
 }
 
 - (void)initAudioSessionObserver{
     audioSession = [AVAudioSession sharedInstance];
-    [audioSession setActive:YES error:nil];
     [audioSession addObserver:self forKeyPath:@"outputVolume" options:0 context:nil];
 }
 

--- a/ios/ReactNativeVolumeController/ReactNativeVolumeController.m
+++ b/ios/ReactNativeVolumeController/ReactNativeVolumeController.m
@@ -67,11 +67,9 @@ RCT_EXPORT_MODULE()
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context{
-    if ([keyPath isEqual:@"outputVolume"]) {
-        float newVolume = [[AVAudioSession sharedInstance] outputVolume];
-        // send JS event
-            [self sendEventWithName:@"RNVolumeEvent" body:@{@"volume": [NSNumber numberWithFloat: newVolume]}];
-        
+    if ([keyPath isEqual:@"outputVolume"] && hasListeners) {
+            float newVolume = [[AVAudioSession sharedInstance] outputVolume];
+            [self sendEventWithName:@"VolumeChanged" body:@{@"volume": [NSNumber numberWithFloat: newVolume]}];
     }
 }
 


### PR DESCRIPTION
- I disabled events in Android. I haven't been able to capture the volume change event there yet.
- Renamed the event to `VolumeChanged` 
- Uses the main queue for threading in iOS