### PR TITLE
fix ios Volume listener bug

### DIFF
--- a/ios/RNVolumeControl/RNVolumeControl.m
+++ b/ios/RNVolumeControl/RNVolumeControl.m
@@ -46,6 +46,7 @@ RCT_EXPORT_MODULE(VolumeControl)
 
 - (void)initAudioSessionObserver{
     audioSession = [AVAudioSession sharedInstance];
+    [audioSession setActive:YES error:nil];
     [audioSession addObserver:self forKeyPath:@"outputVolume" options:0 context:nil];
 }
 


### PR DESCRIPTION
This is fix when running on my iPhone XS iOS 12.2 bug.
didn't catch volume change.